### PR TITLE
SRTM lookups MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ to make sure that they are built with the exact versions of the above dependenci
 ## Basic usage
 
 1. Put an input file in `input/`, and make sure `output/` and `data/` folders exist
-2. `python3`
+2. `python3 main.py inputfilename`
 
 ## Data sources
 

--- a/datasources.json
+++ b/datasources.json
@@ -15,7 +15,7 @@
 		{
 			"name": "SRTM Poundbury",
 			"url": "https://www.usgs.gov/centers/eros/science/usgs-eros-archive-digital-elevation-shuttle-radar-topography-mission-srtm-1-arc",
-			"filename": "srtm_3W50N2W51N_dorchester.tif",
+			"filename": "srtm_poundbury.tif",
 			"crs": "EPSG:4326",
 			"bbox": [-3,50, -2,51],
 			"download_method": "srtm",

--- a/datasources.json
+++ b/datasources.json
@@ -6,9 +6,22 @@
 			"filename": "seattle_contours.geojson",
 			"crs": "EPSG:4326",
 			"bbox": [-122.4359526776817120,47.4448428851168060, -122.2173553791662357,47.7779711955390596],
+			"download_method": "url",
 			"lookup_method": "contour_lines",
 			"lookup_field": "CL93_ELEV",
 			"units": "feet",
+			"recheck_interval_days": 30
+		},
+		{
+			"name": "SRTM Poundbury",
+			"url": "https://www.usgs.gov/centers/eros/science/usgs-eros-archive-digital-elevation-shuttle-radar-topography-mission-srtm-1-arc",
+			"filename": "srtm_3W50N2W51N_dorchester.tif",
+			"crs": "EPSG:4326",
+			"bbox": [-3,50, -2,51],
+			"download_method": "srtm",
+			"lookup_method": "raster",
+			"lookup_field": "",
+			"units": "metres",
 			"recheck_interval_days": 30
 		}
 	]

--- a/main.py
+++ b/main.py
@@ -39,8 +39,7 @@ __license__ = "Apache"
 @click.option(
     '--log',
     type=click.Choice(
-        ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
-        case_sensitive=False
+        ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
     ),
     default='INFO',
     help=('Logging level.  '

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-click==7.1.2
+click==6.7
+elevation==1.1.2
 flake8==3.8.4
 geopandas==0.9.0
 mypy==0.812

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ flake8==3.8.4
 geopandas==0.9.0
 mypy==0.812
 pygeos==0.9
+rasterio==1.2.1
 requests==2.25.1
 rtree==0.9.7
 shapely==1.7.1


### PR DESCRIPTION
This is a very minimal implementation of SRTM.  The `elevation` module can only download source tiles, not stitch them together, and source tile breaks are on whole number degrees.  So this implementation can only support input files which don't cross an integer line of latitude or longitude.  The good news is that lookups are very fast: 8 seconds to process the whole Poundbury sample, + 1 if the SRTM data weren't already locally cached.

I can see a fairly straightforward way to get around the integer degrees issue by just making a series of requests to `elevation`, saving each tile locally and stitching together relevant chunks in memory.  But it'll be just enough work to do that it seemed worth making this PR first.