### PR TITLE
SRTM lookups now work across integer lat/lon lines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ For now:
 * run everything through `python3 -m flake8 *.py --ignore=E303,W504` before making a PR.
 * Use mypy to check typing consistency.  It is AOK to tell it to ignore missing type hints from PEP imports, but all code in this project must have full type hints.
 * Use a [virtual environment](https://docs.python.org/3/library/venv.html) to make sure that all Python dependencies are in [requirements.txt](requirements.txt) and all non-Python dependencies are described in [the readme](README.md).
+* Also test the Docker build, if you weren't developing in that in the first place.
 
 
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ The output should appear in your local `output` directory.
 
 ## Data source options
 
-By default, this project will use SRTM data to look up elevations.  This dataset has the advantage of global availability and ease of use, but it is limited by a 30m pixel size and 1m vertical resolution.  It is also possible to configure locally preferred data sources.  See [#adding-or-editing-data-sources](below) for details on how to add sources.  These are the available types and examples that are preconfigured in this project:
+By default, this project will use SRTM data to look up elevations.  This dataset has the advantage of global availability and ease of use, but it is limited by a coarse pixel size and 1m vertical resolution.  The pixel size between 56S and 60N is 0.00027̅°, which equates to 30m E-W at the equator and 15m E-W at 60N, and 30m N-S at any latitude.  In theory, the pixels triple in size at latitudes outside the range (56S, 60N), though in testing we are still finding 0.00027̅° pixels for Anchorage, Alaska, USA (> 61N).
+
+It is also possible to configure locally preferred data sources.  See [#adding-or-editing-data-sources](below) for details on how to do so.  These are the available types and examples that are preconfigured in this project:
 
 ### Contour lines
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ This is intended as a way of addressing https://github.com/a-b-street/abstreet/i
 
 This utility is being developed and tested in Python 3.9.2 on a Mac, and should in theory work with older versions of Python 3.  Before installing the modules listed in [requirements.txt](requirements.txt), make sure the following are present in the environment in which it will run:
 
-* [GDAL](https://www.gdal.org/), tested with version 3.2.1, should in theory work with any version >= 3.0.4.
 * [GEOS](https://trac.osgeo.org/geos), tested with versions 3.6.2 & 3.9.1, should in theory work with any version >= 3.3.9.
 * [PROJ](https://proj.org/), tested with versions 7.2.1 & 8.0.0, should in theory work with any version >= 7.2.0.
 
@@ -17,6 +16,14 @@ Then install the Python modules with:
 `pip3 install -r requirements.txt --no-binary pygeos --no-binary shapely`
 
 to make sure that they are built with the exact versions of the above dependencies that are present in the environment.  This makes spatial lookups significantly faster.
+
+#### Special note on dependencies
+
+In theory, this project should also have the following dependency, because [rasterio needs it to build](https://rasterio.readthedocs.io/en/latest/installation.html#dependencies):
+
+* [GDAL](https://www.gdal.org/), tested with version 3.2.1, should in theory work with any version >= 1.11.
+
+However, in practice installing rasterio via [requirements.txt](requirements.txt) without the `--no-binary` flag works without having GDAL installed, and at the time of writing everything that this project does with rasterio works without GDAL present in the environment.  I am leaving this note here in case future work makes GDAL necessary again.
 
 ### Docker
 

--- a/README.md
+++ b/README.md
@@ -48,21 +48,21 @@ The output should appear in your local `output` directory.
 
 By default, this project will use SRTM data to look up elevations.  This dataset has the advantage of global availability and ease of use, but it is limited by a coarse pixel size and 1m vertical resolution.  The pixel size between 56S and 60N is 0.00027̅°, which equates to 30m E-W at the equator and 15m E-W at 60N, and 30m N-S at any latitude.  In theory, the pixels triple in size at latitudes outside the range (56S, 60N), though in testing we are still finding 0.00027̅° pixels for Anchorage, Alaska, USA (> 61N).
 
-It is also possible to configure locally preferred data sources.  See [#adding-or-editing-data-sources](below) for details on how to do so.  These are the available types and examples that are preconfigured in this project:
+It is also possible to configure locally preferred data sources.  See [below](#adding-or-editing-data-sources) for details on how to do so.  These are the available types and examples that are preconfigured in this project:
 
 ### Contour lines
 
-Data files may be in any of the [https://gdal.org/drivers/vector/index.html](vector formats supported by GDAL), though note that for formats not marked as "Built-in by default" you may need to install additional prerequisites.  All common vector formats are supported by default.
+Data files may be in any of the [vector formats supported by GDAL](https://gdal.org/drivers/vector/index.html), though note that for formats not marked as "Built-in by default" you may need to install additional prerequisites.  All common vector formats are supported by default.
 
-The enclosed [datasources.json](datasources.json) sets up [https://data-seattlecitygis.opendata.arcgis.com/datasets/contour-lines-1993](Seattle's open 2ft contour dataset) as an example.
+The enclosed [datasources.json](datasources.json) sets up [Seattle's open 2ft contour dataset](https://data-seattlecitygis.opendata.arcgis.com/datasets/contour-lines-1993) as an example.
 
 **Important note**: a point's elevation is taken only from the nearest contour to it, with no attempt to interpolate.  This works well for 2ft contours in a hilly area, but may become a significant source of error for flatter regions or more widely spaced contours.
 
 ### Raster elevation data
 
-Data files may be in any of the [https://gdal.org/drivers/raster/index.html](raster formats supported by GDAL), though note that for formats not marked as "Built-in by default" you may need to install additional prerequisites.  All common raster formats are supported by default.
+Data files may be in any of the [raster formats supported by GDAL](https://gdal.org/drivers/raster/index.html), though note that for formats not marked as "Built-in by default" you may need to install additional prerequisites.  All common raster formats are supported by default.
 
-The enclosed [datasources.json](datasources.json) sets up "Delivery 1" from the Puget Sound LiDAR Consortium's [http://pugetsoundlidar.ess.washington.edu/lidardata/restricted/projects/2016king_county.html](2016 King County data) as an example.  It covers Seattle as well as some additional area S and E of Seattle.  Because it is defined after the Seattle 2ft contours, the contour dataset is used if it covers the required area, falling back to this LIDAR set for input files that are covered by it but not the contours.
+The enclosed [datasources.json](datasources.json) sets up "Delivery 1" from the Puget Sound LiDAR Consortium's [2016 King County data](http://pugetsoundlidar.ess.washington.edu/lidardata/restricted/projects/2016king_county.html) as an example.  It covers Seattle as well as some additional area S and E of Seattle.  Because it is defined after the Seattle 2ft contours, the contour dataset is used if it covers the required area, falling back to this LIDAR set for input files that are covered by it but not the contours.
 
 ## Input format
 
@@ -86,7 +86,7 @@ Data sources are defined in [datasources.json](datasources.json).  The order of 
 
 * `name`: a name for human readability
 * `url`: URL to download data from; if using a file that's already saved locally this field can be set to `null` or used to note the original source
-* `filename`: a filename to save a local copy as, into the data/ directory
+* `filename`: a filename to save a local copy as, into the data/ directory, or at which to find a pre-saved local copy
 *	`crs`: the coordinate reference system of the original data file as a string in the format "EPSG:4326".  Any CRS that PROJ can handle works; files will be converted to EPSG:4326 on loading if they aren't already in that
 * `bbox`: WSEN coordinates for the area covered by this file
 * `download_method`: how to obtain the file.  Currently supported values:

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This is intended as a way of addressing https://github.com/a-b-street/abstreet/i
 This utility is being developed and tested in Python 3.9.2 on a Mac, and should in theory work with older versions of Python 3.  Before installing the modules listed in [requirements.txt](requirements.txt), make sure the following are present in the environment in which it will run:
 
 * [GDAL](https://www.gdal.org/), tested with version 3.2.1, should in theory work with any version >= 3.0.4.
-* [GEOS](https://trac.osgeo.org/geos), tested with version 3.9.1, should in theory work with any version >= 3.3.9.
-* [PROJ](https://proj.org/), tested with version 7.2.1, should in theory work with any version >= 7.2.0.
+* [GEOS](https://trac.osgeo.org/geos), tested with versions 3.6.2 & 3.9.1, should in theory work with any version >= 3.3.9.
+* [PROJ](https://proj.org/), tested with versions 7.2.1 & 8.0.0, should in theory work with any version >= 7.2.0.
 
 Then install the Python modules with:
 
@@ -20,7 +20,7 @@ to make sure that they are built with the exact versions of the above dependenci
 
 ### Docker
 
-If you're having trouble getting dependencies installed, you can try Docker. Build the image locally by doing `docker build -t elevation_lookup .`. You can then use it by binding directories on your filesystem to the Docker container. Assuming you've created a file called `input/my_query`:
+If you're having trouble getting dependencies installed, you can try Docker. Build the image locally by doing `docker build -t elevation_lookups .`. You can then use it by binding directories on your filesystem to the Docker container. Assuming you've created a file called `input/my_query`:
 
 ```
 docker run \

--- a/data.py
+++ b/data.py
@@ -32,15 +32,6 @@ NULL_ELEVATION: float = -11000  # deeper than the deepest ocean
 
 
 
-def pad_bounds(bounds: List[float], padding: float) -> List[float]:
-    return [
-        bounds[0] - padding,
-        bounds[1] - padding,
-        bounds[2] + padding,
-        bounds[3] + padding
-    ]
-
-
 
 class ElevationStats:
 
@@ -149,11 +140,6 @@ class DataSource:
             elif self.download_method == "ftp":
                 self.logger.info('Downloading %s as ftp', self.url)
                 print(ftp.urlretrieve(self.url, self.filename))
-            elif self.download_method == "srtm":
-                eio.clip(
-                    bounds=pad_bounds(bbox.bounds, 0.001),
-                    output=os.path.join(os.getcwd(), self.filename)
-                )
             elif self.download_method == "local":
                 self.logger.critical(
                     'Local file %s not found.',
@@ -190,6 +176,7 @@ class DataSource:
         ]
         for x in range(tiles[0], tiles[2]):
             for y in range(tiles[1], tiles[3]):
+                print(x, y)
                 filename = os.path.join(
                     os.getcwd(),
                     self.filename,

--- a/data.py
+++ b/data.py
@@ -159,7 +159,7 @@ class DataSource:
     def __configure_srtm__(self, bbox: box) -> None:
         self.name = "SRTM 30m"
         self.url = "https://lpdaac.usgs.gov/products/srtmgl1nv003/"
-        self.filename = os.path.join(self.data_dir, "srtm")
+        self.filename = os.path.join(os.getcwd(), self.data_dir, "srtm")
         if not os.path.exists(self.filename):
             os.mkdir(self.filename)
         self.source_crs = "EPSG:4326"
@@ -176,9 +176,7 @@ class DataSource:
         ]
         for x in range(tiles[0], tiles[2]):
             for y in range(tiles[1], tiles[3]):
-                print(x, y)
                 filename = os.path.join(
-                    os.getcwd(),
                     self.filename,
                     "srtm." + str(x) + "." + str(y) + ".tif"
                 )

--- a/data.py
+++ b/data.py
@@ -11,6 +11,10 @@ import warnings
 
 import elevation as eio  # type: ignore
 # elevation is an SRTM downloader.  See https://github.com/bopen/elevation
+import fiona  # type: ignore  #noqa F401
+# fiona is only used indirectly, but needs to be explicitly imported to avoid:
+# ` AttributeError: partially initialized module 'fiona' has no
+# attribute '_loading' (most likely due to a circular import) `
 import geopandas as gp  # type: ignore
 import pyproj
 import rasterio  # type: ignore

--- a/data.py
+++ b/data.py
@@ -202,9 +202,13 @@ class DataSource:
                 self.logger.info('Downloading %s', filename)
             if file_needed:
                 eio.clip(bounds=[x, y, x + 1, y + 1], output=filename)
-        self.logger.info('Loading SRTM raster data cropped to %s', bbox.bounds)
         # merge files to temp.tif on disk
         self.filename = os.path.join(self.filename, "temp.tif")
+        self.logger.info(
+            'Saving SRTM data cropped to %s as %s',
+            bbox.bounds,
+            self.filename
+        )
         rasterio.merge.merge(
             self.srtm_tiles,
             bounds=bbox.bounds,

--- a/data.py
+++ b/data.py
@@ -114,6 +114,17 @@ class DataSource:
             'No applicable data sources found in %s, defaulting to SRTM.',
             self.sources_file
         )
+        self.name = "SRTM 30m"
+        self.url = "https://lpdaac.usgs.gov/products/srtmgl1nv003/"
+        self.filename = os.path.join(os.getcwd(), self.data_dir, "srtm")
+        if not os.path.exists(self.filename):
+            os.mkdir(self.filename)
+        self.source_crs = "EPSG:4326"
+        self.download_method = "srtm"
+        self.lookup_method = "raster"
+        self.lookup_field = "1"
+        self.source_units = "meters"
+        self.recheck_days = 100
         self.__download_srtm__(bbox)
 
 
@@ -158,18 +169,6 @@ class DataSource:
 
 
     def __download_srtm__(self, bbox: box) -> None:
-        # hard-code some metadata
-        self.name = "SRTM 30m"
-        self.url = "https://lpdaac.usgs.gov/products/srtmgl1nv003/"
-        self.filename = os.path.join(os.getcwd(), self.data_dir, "srtm")
-        if not os.path.exists(self.filename):
-            os.mkdir(self.filename)
-        self.source_crs = "EPSG:4326"
-        self.download_method = "srtm"
-        self.lookup_method = "raster"
-        self.lookup_field = "1"
-        self.source_units = "meters"
-        self.recheck_days = 100
         # make a list of file[s] needed
         tiles: List[int] = [
             math.floor(bbox.bounds[0]),

--- a/datasources.json
+++ b/datasources.json
@@ -23,18 +23,6 @@
 			"lookup_field": 1,
 			"units": "feet",
 			"recheck_interval_days": 100
-		},
-		{
-			"name": "SRTM Poundbury",
-			"url": null,
-			"filename": "srtm_poundbury.tif",
-			"crs": "EPSG:4326",
-			"bbox": [-3,50, -2,51],
-			"download_method": "local",
-			"lookup_method": "raster",
-			"lookup_field": 1,
-			"units": "metres",
-			"recheck_interval_days": null
 		}
 	]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 click==6.7
 elevation==1.1.2
+Fiona==1.8.18
 flake8==3.8.4
 geopandas==0.9.0
 mypy==0.812


### PR DESCRIPTION
In this PR:

- SRTM is no longer explicitly configurable as a datasource.  Instead it's the global fallback any time that none of the explicitly configured datasources cover the area we need.
- SRTM is downloaded as 1x1 degree tiles, breaking on integer lines of latitude & longitude because that seems to be the most robust.
- If an input file spans more than one of those files, `rasterio.merge` is used to combine them
- Also some minor documentation housekeeping

Tagging Anchorage (14,121 paths, spans across -150 longitude) takes 1m30s on my machine.

Work for the rest of this week, unless @dabreegster thinks these no longer make sense:

1. Parallelising lookups
2. Turning CONTRIBUTING.md into a usable document

Possible later steps:

- Do we still need to figure out a workaround for bridges?  Probably better to discuss this offline; may depend on how raster data looks for Seattle.