### PR TITLE
Get SRTM working with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM osgeo/proj
+FROM osgeo/gdal
 
 # https://stackoverflow.com/questions/52065842/python-docker-ascii-codec-cant-encode-character
 ENV LANG C.UTF-8

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This is intended as a way of addressing https://github.com/a-b-street/abstreet/i
 
 ## Installation / requirements
 
-This utility is being developed and tested in Python 3.9.2 on a Mac, and should in theory work with older versions of Python 3.  Before installing the modules listed in [requirements.txt](requirements.txt), make sure the following are present in the environment in which it will run:
+This utility is being developed and tested in Python 3.9.2 on a Mac & 3.8.5 on Linux, and should in theory work with older versions of Python 3.  Before installing the modules listed in [requirements.txt](requirements.txt), make sure the following are present in the environment in which it will run:
 
-* [GDAL](https://www.gdal.org/), tested with version 3.2.1, should in theory work with any version >= 3.0.4.
+* [GDAL](https://www.gdal.org/), tested with versions 3.2.0 - 3.2.2, should in theory work with any version >= 3.0.4.
 * [GEOS](https://trac.osgeo.org/geos), tested with versions 3.6.2 & 3.9.1, should in theory work with any version >= 3.3.9.
 * [PROJ](https://proj.org/), tested with versions 7.2.1 & 8.0.0, should in theory work with any version >= 7.2.0.
 


### PR DESCRIPTION
1) Installing libspatialindex-dev started failing because of 404, so I added an `apt-get update` first
2) The SRTM download failed, because the base image doesn't have curl by default

With these changes, I've successfully run the tool on montlake for all 3 data sources. Analyzing them now.