### PR TITLE
Assorted cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is intended as a way of addressing https://github.com/a-b-street/abstreet/i
 
 This utility is being developed and tested in Python 3.9.2 on a Mac, and should in theory work with older versions of Python 3.  Before installing the modules listed in [requirements.txt](requirements.txt), make sure the following are present in the environment in which it will run:
 
+* [GDAL](https://www.gdal.org/), tested with version 3.2.1, should in theory work with any version >= 3.0.4.
 * [GEOS](https://trac.osgeo.org/geos), tested with versions 3.6.2 & 3.9.1, should in theory work with any version >= 3.3.9.
 * [PROJ](https://proj.org/), tested with versions 7.2.1 & 8.0.0, should in theory work with any version >= 7.2.0.
 
@@ -16,14 +17,6 @@ Then install the Python modules with:
 `pip3 install -r requirements.txt --no-binary pygeos --no-binary shapely`
 
 to make sure that they are built with the exact versions of the above dependencies that are present in the environment.  This makes spatial lookups significantly faster.
-
-#### Special note on dependencies
-
-In theory, this project should also have the following dependency, because [rasterio needs it to build](https://rasterio.readthedocs.io/en/latest/installation.html#dependencies):
-
-* [GDAL](https://www.gdal.org/), tested with version 3.2.1, should in theory work with any version >= 1.11.
-
-However, in practice installing rasterio via [requirements.txt](requirements.txt) without the `--no-binary` flag works without having GDAL installed, and at the time of writing everything that this project does with rasterio works without GDAL present in the environment.  I am leaving this note here in case future work makes GDAL necessary again.
 
 ### Docker
 

--- a/data.py
+++ b/data.py
@@ -159,7 +159,7 @@ class DataSource:
                     outfile.write(req.content)
             elif self.download_method == "ftp":
                 self.logger.info('Downloading %s as ftp', self.url)
-                print(ftp.urlretrieve(self.url, self.filename))
+                ftp.urlretrieve(self.url, self.filename)
             elif self.download_method == "local":
                 self.logger.critical(
                     'Local file %s not found.',

--- a/data.py
+++ b/data.py
@@ -81,6 +81,14 @@ class DataSource:
             exit(1)
 
 
+    def __enter__(self):
+        return self
+
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.close()
+
+
     def __choose_source__(self, bbox: box) -> None:
         # load available sources from metadata JSON
         with open(self.sources_file) as infile:
@@ -202,9 +210,11 @@ class DataSource:
             if file_needed:
                 eio.clip(bounds=[x, y, x + 1, y + 1], output=filename)
         # merge files to temp.tif on disk
+        tile_id: str = str(tiles[0]) + "_" + str(tiles[1])
+        tile_id += "_" + str(tiles[2]) + "_" + str(tiles[3])
         self.filename = os.path.join(
             self.filename,
-            "temp_" + str(time.time_ns()) + ".tif"
+            "temp_" + tile_id + "_" + str(time.time()) + ".tif"
         )
         self.logger.info(
             'Saving SRTM data cropped to %s as %s',
@@ -364,6 +374,7 @@ class DataSource:
         if self.lookup_method == "raster":
             self.raster_dataset.close()
         if self.download_method == "srtm":
+            self.logger.info('Removing temp data file %s', self.filename)
             os.remove(self.filename)
 
 

--- a/data.py
+++ b/data.py
@@ -209,7 +209,7 @@ class DataSource:
                 self.logger.info('Downloading %s', filename)
             if file_needed:
                 eio.clip(bounds=[x, y, x + 1, y + 1], output=filename)
-        # merge files to temp.tif on disk
+        # merge files to temp.....tif on disk
         tile_id: str = str(tiles[0]) + "_" + str(tiles[1])
         tile_id += "_" + str(tiles[2]) + "_" + str(tiles[3])
         self.filename = os.path.join(

--- a/data.py
+++ b/data.py
@@ -202,7 +202,10 @@ class DataSource:
             if file_needed:
                 eio.clip(bounds=[x, y, x + 1, y + 1], output=filename)
         # merge files to temp.tif on disk
-        self.filename = os.path.join(self.filename, "temp.tif")
+        self.filename = os.path.join(
+            self.filename,
+            "temp_" + str(time.time_ns()) + ".tif"
+        )
         self.logger.info(
             'Saving SRTM data cropped to %s as %s',
             bbox.bounds,
@@ -355,6 +358,13 @@ class DataSource:
             # after the loop, we already have our final elevation
             stats.end = elevation
         return stats
+
+
+    def close(self) -> None:
+        if self.lookup_method == "raster":
+            self.raster_dataset.close()
+        if self.download_method == "srtm":
+            os.remove(self.filename)
 
 
     def __str__(self) -> str:

--- a/files.py
+++ b/files.py
@@ -83,13 +83,7 @@ class InputFile:
             coords.append((vals[0], vals[1]))
         return LineString(coords)
 
-    def process(
-        self,
-        d: DataSource,
-        outfile: OutputFile,
-        n_threads: int
-    ) -> None:
-        self.logger.debug('Processing with %s threads', n_threads)
+    def process(self, d: DataSource, outfile: OutputFile) -> None:
         for line in self.__paths:
             vals: ElevationStats = d.process(line)
             outfile.write_elevations(vals)

--- a/files.py
+++ b/files.py
@@ -83,7 +83,13 @@ class InputFile:
             coords.append((vals[0], vals[1]))
         return LineString(coords)
 
-    def process(self, d: DataSource, outfile: OutputFile) -> None:
+    def process(
+        self,
+        d: DataSource,
+        outfile: OutputFile,
+        n_threads: int
+    ) -> None:
+        self.logger.debug('Processing with %s threads', n_threads)
         for line in self.__paths:
             vals: ElevationStats = d.process(line)
             outfile.write_elevations(vals)

--- a/files.py
+++ b/files.py
@@ -43,6 +43,12 @@ class OutputFile:
         self.f.write(str(round(data.descent, SAVE_PRECISION)))
         self.f.write('\n')
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.close()
+
     def close(self) -> None:
         self.f.close()
 

--- a/main.py
+++ b/main.py
@@ -37,6 +37,12 @@ __license__ = "Apache"
             'or leave out for default value: "datasources.json"')
 )
 @click.option(
+    '--n_threads',
+    default=5,
+    help=('Number of threads to execute in parallel, '
+            'or leave out for default value: 5')
+)
+@click.option(
     '--log',
     type=click.Choice(
         ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
@@ -53,6 +59,7 @@ def main(
     output_dir: str,
     data_source_list: str,
     input_file: str,
+    n_threads: int,
     log: str
 ) -> None:
     start_time: float = time.time()
@@ -66,7 +73,7 @@ def main(
     infile = InputFile(__name__, input_dir, input_file)
     with DataSource(__name__, data_dir, data_source_list, infile.bbox()) as d:
         with OutputFile(__name__, output_dir, input_file) as outfile:
-            infile.process(d, outfile)
+            infile.process(d, outfile, n_threads)
     logger.info("Run complete in %s.", elapsedTime(start_time))
 
 

--- a/main.py
+++ b/main.py
@@ -68,6 +68,7 @@ def main(
     outfile = OutputFile(__name__, output_dir, input_file)
     infile.process(d, outfile)
     outfile.close()
+    d.close()
     logger.info("Run complete in %s.", elapsedTime(start_time))
 
 

--- a/main.py
+++ b/main.py
@@ -64,11 +64,9 @@ def main(
     logger.setLevel(level=log)
     logger.debug("Starting run")
     infile = InputFile(__name__, input_dir, input_file)
-    d = DataSource(__name__, data_dir, data_source_list, infile.bbox())
-    outfile = OutputFile(__name__, output_dir, input_file)
-    infile.process(d, outfile)
-    outfile.close()
-    d.close()
+    with DataSource(__name__, data_dir, data_source_list, infile.bbox()) as d:
+        with OutputFile(__name__, output_dir, input_file) as outfile:
+            infile.process(d, outfile)
     logger.info("Run complete in %s.", elapsedTime(start_time))
 
 

--- a/main.py
+++ b/main.py
@@ -37,12 +37,6 @@ __license__ = "Apache"
             'or leave out for default value: "datasources.json"')
 )
 @click.option(
-    '--n_threads',
-    default=5,
-    help=('Number of threads to execute in parallel, '
-            'or leave out for default value: 5')
-)
-@click.option(
     '--log',
     type=click.Choice(
         ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
@@ -59,7 +53,6 @@ def main(
     output_dir: str,
     data_source_list: str,
     input_file: str,
-    n_threads: int,
     log: str
 ) -> None:
     start_time: float = time.time()
@@ -73,7 +66,7 @@ def main(
     infile = InputFile(__name__, input_dir, input_file)
     with DataSource(__name__, data_dir, data_source_list, infile.bbox()) as d:
         with OutputFile(__name__, output_dir, input_file) as outfile:
-            infile.process(d, outfile, n_threads)
+            infile.process(d, outfile)
     logger.info("Run complete in %s.", elapsedTime(start_time))
 
 


### PR DESCRIPTION
I'm having a harder time with parallelisation than I expected to, so I'll return to that tomorrow or possibly on Thursday after addressing https://github.com/eldang/elevation_lookups/issues/13 .  So here's a very small increment of work:

1. Reverts the README change yesterday which claimed that GDAL's not really a dependency, because https://github.com/eldang/elevation_lookups/issues/9#issuecomment-805337411 revealed that it is.
2. Makes the SRTM subsystem give its temp files unique names and delete them at the end of a run, so that multiple instances of this project can run in parallel using the same `data` directory.  This is probably not a particularly useful form of parallelisation, but it seems like better behaviour anyway.
3. Sets up both objects that need a `close()` method so they can be called as context managers, just because I find that syntax tidier and more pythonic.
4. Removes some debug output