### PR TITLE
Workaround for impossible elevation values

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Some things to note:
 * Any non-zero `total_descent` is expressed as a positive value, i.e. a path that descends by 1 metre will have a value of 1
 * `total_climb` and `total_descent` include intermediate ups and downs along the path, so it is not unusual for both to be non-zero, and in that case one of them will be larger than the difference between `start_elevation` and `end_elevation`
 * (`start_elevation` - `end_elevation` + `total_climb` - `total_descent`) should always be within 1mm of 0.
+* If the utility is unable to find elevations for any of the points in a given input line, it will write a blank line to the output file.
+* If the utility is able to find elevations for some but not all of the points in an input line, it will assume that the missing points have the same elevation as their neighbours.
 
 ## Adding or editing data sources
 

--- a/files.py
+++ b/files.py
@@ -8,7 +8,7 @@ from typing import List, Tuple
 
 from shapely.geometry import box, LineString, MultiLineString  # type: ignore
 
-from data import DataSource, ElevationStats
+from data import DataSource, ElevationStats, NULL_ELEVATION
 
 
 
@@ -34,13 +34,15 @@ class OutputFile:
         self.f = open(self.file_path, 'w')
 
     def write_elevations(self, data: ElevationStats) -> None:
-        self.f.write(str(round(data.start, SAVE_PRECISION)))
-        self.f.write('\t')
-        self.f.write(str(round(data.end, SAVE_PRECISION)))
-        self.f.write('\t')
-        self.f.write(str(round(data.climb, SAVE_PRECISION)))
-        self.f.write('\t')
-        self.f.write(str(round(data.descent, SAVE_PRECISION)))
+        # skip NULL returns
+        if data.start != NULL_ELEVATION and data.end != NULL_ELEVATION:
+            self.f.write(str(round(data.start, SAVE_PRECISION)))
+            self.f.write('\t')
+            self.f.write(str(round(data.end, SAVE_PRECISION)))
+            self.f.write('\t')
+            self.f.write(str(round(data.climb, SAVE_PRECISION)))
+            self.f.write('\t')
+            self.f.write(str(round(data.descent, SAVE_PRECISION)))
         self.f.write('\n')
 
     def __enter__(self):


### PR DESCRIPTION
This implements the simplest approach I can think of to https://github.com/eldang/elevation_lookups/issues/13 , i.e.:

- If the first point in a line gets an impossibly negative elevation, skip that point and keep going until we get a plausible value for something.
- If there are no valid values for the whole line, just write a blank line to the output file instead of garbage.
- If later points in a line get impossibly negative elevations, just assume that their real elevation is the same as their predecessor.