### PR TITLE
Parallelisation (all lookups)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The output should appear in your local `output` directory.
 1. Put an input file in `input/`, and make sure `output/` and `data/` folders exist
 2. `python3 main.py inputfilename`
 
-To specify how many parallel processes will be spawned to process the input, add the argument `--n_threads=X`.  If X == 1 then parallel processing will be sidestepped entirely; this can be useful for debugging.  If this argument is not set, then the script will default to using as many threads as CPUs are present.
+To specify how many parallel processes will be spawned to process the input, add the argument `--n_threads=X`.  If X == 1 then parallel processing will be sidestepped entirely; this can be useful for debugging.  If this argument is not set, then the script will default to using as many processes as CPUs are present.  **Note that parallel raster processing can have a heavy memory footprint**: specifically, each parallel process loads its own copy of the elevation data source, windowed to the bounding box of the input data.  So for a large area and a high resolution raster data source, memory may be a tighter practical constraint on parallel processing than CPU availability.
 
 ## Data source options
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is intended as a way of addressing https://github.com/a-b-street/abstreet/i
 
 This utility is being developed and tested in Python 3.9.2 on a Mac, and should in theory work with older versions of Python 3.  Before installing the modules listed in [requirements.txt](requirements.txt), make sure the following are present in the environment in which it will run:
 
-* [GDAL](https://www.gdal.org/), tested with version 3.2.1, should in theory work with any version >= 3.0.4.
+* [GDAL](https://www.gdal.org/), tested with versions 3.2.1 & 3.2.2, should in theory work with any version >= 3.0.4.
 * [GEOS](https://trac.osgeo.org/geos), tested with versions 3.6.2 & 3.9.1, should in theory work with any version >= 3.3.9.
 * [PROJ](https://proj.org/), tested with versions 7.2.1 & 8.0.0, should in theory work with any version >= 7.2.0.
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ The output should appear in your local `output` directory.
 1. Put an input file in `input/`, and make sure `output/` and `data/` folders exist
 2. `python3 main.py inputfilename`
 
+To specify how many parallel processes will be spawned to process the input, add the argument `--n_threads=X`.  If X == 1 then parallel processing will be sidestepped entirely; this can be useful for debugging.
+
 ## Data source options
 
 By default, this project will use SRTM data to look up elevations.  This dataset has the advantage of global availability and ease of use, but it is limited by a coarse pixel size and 1m vertical resolution.  The pixel size between 56S and 60N is 0.00027̅°, which equates to 30m E-W at the equator and 15m E-W at 60N, and 30m N-S at any latitude.  In theory, the pixels triple in size at latitudes outside the range (56S, 60N), though in testing we are still finding 0.00027̅° pixels for Anchorage, Alaska, USA (> 61N).

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The enclosed [datasources.json](datasources.json) sets up "Delivery 1" from the 
 
 ## Input format
 
-A text file in which each row is one path, and each row consists of tab-separated x,y coordinate pairs in order to describe a path, in unprojected decimal degrees.
+A text file in which each row is one path, and each row consists of tab-separated x,y coordinate pairs in order to describe a path, in unprojected decimal degrees.  The file should contain no blank lines until the end, as input parsing will stop at the first blank line it encounters.
 
 ## Output format
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The output should appear in your local `output` directory.
 1. Put an input file in `input/`, and make sure `output/` and `data/` folders exist
 2. `python3 main.py inputfilename`
 
-To specify how many parallel processes will be spawned to process the input, add the argument `--n_threads=X`.  If X == 1 then parallel processing will be sidestepped entirely; this can be useful for debugging.
+To specify how many parallel processes will be spawned to process the input, add the argument `--n_threads=X`.  If X == 1 then parallel processing will be sidestepped entirely; this can be useful for debugging.  If this argument is not set, then the script will default to using as many threads as CPUs are present.
 
 ## Data source options
 

--- a/data.py
+++ b/data.py
@@ -357,7 +357,8 @@ class DataSource:
                     workers[i].terminate()
             for i in range(n_threads):
                 workers[i].join()
-                workers[i].close()
+                if hasattr(workers[i], 'close'):
+                    workers[i].close()
             self.logger.debug("Parallel processing complete")
             # output order is not guaranteed, so sort it on returning
             return sorted(vals, key=lambda x: x.i)

--- a/data.py
+++ b/data.py
@@ -282,11 +282,17 @@ class DataSource:
         lines: MultiLineString,
         n_threads: int
     ) -> List[ElevationStats]:
-        self.logger.debug('Processing with %s threads', n_threads)
         vals: List[ElevationStats] = []
-        for i in range(len(lines)):
-            vals.append(self.tag_line(lines[i], i))
-        return vals
+        if n_threads == 1:
+            self.logger.debug('Processing singlethreaded.')
+            for i in range(len(lines)):
+                vals.append(self.tag_line(lines[i], i))
+            return vals
+        else:
+            self.logger.debug('Processing with %s threads', n_threads)
+            for i in range(len(lines)):
+                vals.append(self.tag_line(lines[i], i))
+            return sorted(vals, key=lambda x: x.i)
 
 
     def tag_line(self, line: LineString, i: int) -> ElevationStats:

--- a/data.py
+++ b/data.py
@@ -514,7 +514,7 @@ class DataSource:
         stats.start = self.__raster_point_lookup__(Point(line.coords[0]))
         # deal with nodata returns
         while stats.start <= NULL_ELEVATION:
-            if len(line.coords) <= 1:
+            if len(line.coords) <= 2:
                 return ElevationStats()
             line.coords = line.coords[1:]
             stats.start = self.__raster_point_lookup__(

--- a/data.py
+++ b/data.py
@@ -540,7 +540,7 @@ class DataSource:
                         stats.descent += previous_elevation - elevation
                     previous_elevation = elevation
             # after the loop, we already have our final elevation
-            stats.end = elevation
+            stats.end = previous_elevation
         return stats
 
 

--- a/data.py
+++ b/data.py
@@ -299,7 +299,8 @@ class DataSource:
                 if self.lookup_method == "contour_lines":
                     mp.Process(
                         target=self.__parallel_contour_worker__,
-                        args=(q, out, i, self.logger.getEffectiveLevel())
+                        args=(q, out, i, self.logger.getEffectiveLevel()),
+                        daemon=True
                     ).start()
                 elif self.lookup_method == "raster":
                     mp.Process(
@@ -310,7 +311,8 @@ class DataSource:
                             box(*lines.bounds),
                             i,
                             self.logger.getEffectiveLevel()
-                        )
+                        ),
+                        daemon=True
                     ).start()
             q.join()
             self.logger.debug("Parallel processing complete")

--- a/data.py
+++ b/data.py
@@ -25,7 +25,7 @@ import requests
 
 from shapely.geometry import box, LineString, MultiLineString, Point  # type: ignore  # noqa: E501
 from shapely.ops import transform  # type: ignore
-from typing import List
+from typing import List, Tuple
 
 
 SCREEN_PRECISION: int = 2  # round terminal output to 1cm
@@ -278,11 +278,11 @@ class DataSource:
         self,
         lines: MultiLineString,
         n_threads: int
-    ) -> List[ElevationStats]:
+    ) -> Tuple[List[ElevationStats], List[mp.Process]]:
         # allow multiprocessing to be sidestepped so there's always an
         # option for simple, sequential runs for debugging purposes
         if n_threads == 1:
-            return self.__serial_worker__(lines)
+            return (self.__serial_worker__(lines), [])
         else:
             self.logger.info('Spawning %s threads', n_threads)
             q: mp.JoinableQueue = mp.JoinableQueue()  # for processing
@@ -294,16 +294,17 @@ class DataSource:
                     "i": i
                 })
             # start an appropriate number of workers
+            workers: List[mp.Process] = []
             for i in range(n_threads):
                 self.logger.debug("Spawning thread %s", i)
                 if self.lookup_method == "contour_lines":
-                    mp.Process(
+                    workers.append(mp.Process(
                         target=self.__parallel_contour_worker__,
                         args=(q, out, i, self.logger.getEffectiveLevel()),
                         daemon=True
-                    ).start()
+                    ))
                 elif self.lookup_method == "raster":
-                    mp.Process(
+                    workers.append(mp.Process(
                         target=self.__parallel_raster_worker__,
                         args=(
                             q,
@@ -313,15 +314,25 @@ class DataSource:
                             self.logger.getEffectiveLevel()
                         ),
                         daemon=True
-                    ).start()
+                    ))
+                workers[i].start()
             q.join()
-            self.logger.debug("Parallel processing complete")
             # collect all the output into one list
             vals: List[ElevationStats] = []
-            while not out.empty():
+            while len(vals) != len(lines):
+                wait: float = 0.1
+                while(out.empty()):
+                    self.logger.debug(
+                        "Waiting %s seconds for %s more lines of data",
+                        wait,
+                        len(lines) - len(vals)
+                    )
+                    time.sleep(wait)
+                    wait *= 2
                 vals.append(out.get())
+            self.logger.debug("Parallel processing complete")
             # output order is not guaranteed, so sort it on returning
-            return sorted(vals, key=lambda x: x.i)
+            return (sorted(vals, key=lambda x: x.i), workers)
 
 
     def __serial_worker__(

--- a/files.py
+++ b/files.py
@@ -92,7 +92,7 @@ class InputFile:
         n_threads: int
     ) -> None:
         vals: List[ElevationStats] = d.tag_multiline(self.__paths, n_threads)
-        for row in sorted(vals, key=lambda x: x.i):
+        for row in vals:
             outfile.write_elevations(row)
 
     def bbox(self) -> box:

--- a/files.py
+++ b/files.py
@@ -73,7 +73,7 @@ class InputFile:
         lines: List[LineString] = []
         with open(self.file_path) as f:
             for row in f:
-                if row == '\n':
+                if row.strip() == '':
                     break
                 lines.append(self.__build_line__(row))
         self.__paths = MultiLineString(lines)

--- a/files.py
+++ b/files.py
@@ -27,9 +27,12 @@ class OutputFile:
         self.file_path: str = os.path.join(output_dir, output_file)
 
         if os.path.exists(self.file_path):
-            self.logger.info("Overwriting existing %s", self.file_path)
+            self.logger.warning(
+                "Existing %s will be overwritten",
+                self.file_path
+            )
         else:
-            self.logger.info("Creating output file %s", self.file_path)
+            self.logger.info("Output will be saved to new %s", self.file_path)
 
         self.f = open(self.file_path, 'w')
 
@@ -94,6 +97,7 @@ class InputFile:
         n_threads: int
     ) -> None:
         vals: List[ElevationStats] = d.tag_multiline(self.__paths, n_threads)
+        self.logger.info("Writing output to %s", outfile)
         for row in vals:
             outfile.write_elevations(row)
 

--- a/files.py
+++ b/files.py
@@ -85,16 +85,15 @@ class InputFile:
             coords.append((vals[0], vals[1]))
         return LineString(coords)
 
-    def process(
+    def tag_elevations(
         self,
         d: DataSource,
         outfile: OutputFile,
         n_threads: int
     ) -> None:
-        self.logger.debug('Processing with %s threads', n_threads)
-        for line in self.__paths:
-            vals: ElevationStats = d.process(line)
-            outfile.write_elevations(vals)
+        vals: List[ElevationStats] = d.tag_multiline(self.__paths, n_threads)
+        for row in sorted(vals, key=lambda x: x.i):
+            outfile.write_elevations(row)
 
     def bbox(self) -> box:
         return box(*self.__paths.bounds)

--- a/files.py
+++ b/files.py
@@ -83,13 +83,7 @@ class InputFile:
             coords.append((vals[0], vals[1]))
         return LineString(coords)
 
-    def process(
-        self,
-        d: DataSource,
-        outfile: OutputFile,
-        n_threads: int
-    ) -> None:
-        self.logger.debug('Processing with %s threads', n_threads)
+    def process(self, d: DataSource, outfile: OutputFile) -> None:
         for line in self.__paths:
             vals: ElevationStats = d.process(line)
             outfile.write_elevations(vals)

--- a/files.py
+++ b/files.py
@@ -83,7 +83,13 @@ class InputFile:
             coords.append((vals[0], vals[1]))
         return LineString(coords)
 
-    def process(self, d: DataSource, outfile: OutputFile) -> None:
+    def process(
+        self,
+        d: DataSource,
+        outfile: OutputFile,
+        n_threads: int
+    ) -> None:
+        self.logger.debug('Processing with %s threads', n_threads)
         for line in self.__paths:
             vals: ElevationStats = d.process(line)
             outfile.write_elevations(vals)

--- a/files.py
+++ b/files.py
@@ -73,6 +73,8 @@ class InputFile:
         lines: List[LineString] = []
         with open(self.file_path) as f:
             for row in f:
+                if row == '\n':
+                    break
                 lines.append(self.__build_line__(row))
         self.__paths = MultiLineString(lines)
         self.logger.info("Found %s rows in %s", self.n_lines(), self.file_path)

--- a/files.py
+++ b/files.py
@@ -3,7 +3,6 @@
 # file handlers and objects
 
 import logging
-import multiprocessing as mp
 import os
 from typing import List, Tuple
 
@@ -97,19 +96,11 @@ class InputFile:
         outfile: OutputFile,
         n_threads: int
     ) -> None:
-        returns: Tuple = d.tag_multiline(self.__paths, n_threads)
-        vals: List[ElevationStats] = returns[0]
-        workers: List[mp.Process] = returns[1]
+        vals: List[ElevationStats] = d.tag_multiline(self.__paths, n_threads)
         self.logger.info("Writing output to %s", outfile)
         for row in vals:
             outfile.write_elevations(row)
-        # clean up child processes
-        for i in range(n_threads):
-            if workers[i].is_alive():
-                workers[i].terminate()
-        for i in range(n_threads):
-            workers[i].join()
-            workers[i].close()
+
 
     def bbox(self) -> box:
         return box(*self.__paths.bounds)

--- a/files.py
+++ b/files.py
@@ -85,7 +85,13 @@ class InputFile:
             coords.append((vals[0], vals[1]))
         return LineString(coords)
 
-    def process(self, d: DataSource, outfile: OutputFile) -> None:
+    def process(
+        self,
+        d: DataSource,
+        outfile: OutputFile,
+        n_threads: int
+    ) -> None:
+        self.logger.debug('Processing with %s threads', n_threads)
         for line in self.__paths:
             vals: ElevationStats = d.process(line)
             outfile.write_elevations(vals)

--- a/files.py
+++ b/files.py
@@ -3,6 +3,7 @@
 # file handlers and objects
 
 import logging
+import multiprocessing as mp
 import os
 from typing import List, Tuple
 
@@ -96,10 +97,19 @@ class InputFile:
         outfile: OutputFile,
         n_threads: int
     ) -> None:
-        vals: List[ElevationStats] = d.tag_multiline(self.__paths, n_threads)
+        returns: Tuple = d.tag_multiline(self.__paths, n_threads)
+        vals: List[ElevationStats] = returns[0]
+        workers: List[mp.Process] = returns[1]
         self.logger.info("Writing output to %s", outfile)
         for row in vals:
             outfile.write_elevations(row)
+        # clean up child processes
+        for i in range(n_threads):
+            if workers[i].is_alive():
+                workers[i].terminate()
+        for i in range(n_threads):
+            workers[i].join()
+            workers[i].close()
 
     def bbox(self) -> box:
         return box(*self.__paths.bounds)

--- a/main.py
+++ b/main.py
@@ -37,6 +37,12 @@ __license__ = "Apache"
             'or leave out for default value: "datasources.json"')
 )
 @click.option(
+    '--n_threads',
+    default=5,
+    help=('Number of threads to execute in parallel, '
+            'or leave out for default value: 5')
+)
+@click.option(
     '--log',
     type=click.Choice(
         ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
@@ -53,6 +59,7 @@ def main(
     output_dir: str,
     data_source_list: str,
     input_file: str,
+    n_threads: int,
     log: str
 ) -> None:
     start_time: float = time.time()
@@ -66,7 +73,7 @@ def main(
     infile = InputFile(__name__, input_dir, input_file)
     with DataSource(__name__, data_dir, data_source_list, infile.bbox()) as d:
         with OutputFile(__name__, output_dir, input_file) as outfile:
-            infile.process(d, outfile)
+            infile.process(d, outfile, n_threads)
     logger.info("Run complete in %s.", elapsedTime(start_time))
 
 

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@
 # Look up elevation data for a batch of paths
 
 import logging
+import sys
 import time
 
 import click
@@ -75,6 +76,7 @@ def main(
         with OutputFile(__name__, output_dir, input_file) as outfile:
             infile.tag_elevations(d, outfile, n_threads)
     logger.info("Run complete in %s.", elapsedTime(start_time))
+    sys.exit(0)
 
 
 

--- a/main.py
+++ b/main.py
@@ -40,7 +40,7 @@ __license__ = "Apache"
     '--n_threads',
     default=5,
     help=('Number of threads to execute in parallel, '
-            'or leave out for default value: 5')
+            'or leave out for default value: 5')  # noqa: E127
 )
 @click.option(
     '--log',
@@ -73,7 +73,7 @@ def main(
     infile = InputFile(__name__, input_dir, input_file)
     with DataSource(__name__, data_dir, data_source_list, infile.bbox()) as d:
         with OutputFile(__name__, output_dir, input_file) as outfile:
-            infile.process(d, outfile, n_threads)
+            infile.tag_elevations(d, outfile, n_threads)
     logger.info("Run complete in %s.", elapsedTime(start_time))
 
 

--- a/main.py
+++ b/main.py
@@ -37,12 +37,6 @@ __license__ = "Apache"
             'or leave out for default value: "datasources.json"')
 )
 @click.option(
-    '--n_threads',
-    default=5,
-    help=('Number of threads to execute in parallel, '
-            'or leave out for default value: 5')
-)
-@click.option(
     '--log',
     type=click.Choice(
         ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
@@ -59,7 +53,6 @@ def main(
     output_dir: str,
     data_source_list: str,
     input_file: str,
-    n_threads: int,
     log: str
 ) -> None:
     start_time: float = time.time()
@@ -73,7 +66,7 @@ def main(
     infile = InputFile(__name__, input_dir, input_file)
     with DataSource(__name__, data_dir, data_source_list, infile.bbox()) as d:
         with OutputFile(__name__, output_dir, input_file) as outfile:
-            infile.process(d, outfile, n_threads)
+            infile.process(d, outfile)
     logger.info("Run complete in %s.", elapsedTime(start_time))
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ Fiona==1.8.18
 flake8==3.8.4
 geopandas==0.9.0
 mypy==0.812
+psutil==5.8.0
 pygeos==0.9
 rasterio==1.2.1
 requests==2.25.1


### PR DESCRIPTION
Updated: now parallelises both kinds of lookup

- Elevation lookups are now parallelised
- It spawns 5 threads by default, simply because that number is 1 less than the number of cores available on my laptop.  This can be overriding with a command line argument
-  Doing contour lookups in 5 parallel threads roughly halves processing time for the Montlake sample.  The return will be much bigger for larger map areas, because loading the Seattle contours file in the first place takes about a minute.
- Doing raster lookups in 5 parallel threads has a better return: Anchorage went from 83 seconds to 24 in my test run.
- It does preserve row order between input and output.