### PR TITLE
Run apt-get update when building the Docker container, and prefer the…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /elevation
 COPY . .
 
 # Build dependencies
+RUN apt-get update
 RUN apt-get install -y python3-pip libgeos-dev libspatialindex-dev
 RUN pip3 install Cython numpy
 RUN pip3 install -r requirements.txt --no-binary pygeos --no-binary shapely

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ It is also possible to configure locally preferred data sources.  See [below](#a
 
 Data files may be in any of the [vector formats supported by GDAL](https://gdal.org/drivers/vector/index.html), though note that for formats not marked as "Built-in by default" you may need to install additional prerequisites.  All common vector formats are supported by default.
 
-The enclosed [datasources.json](datasources.json) sets up [Seattle's open 2ft contour dataset](https://data-seattlecitygis.opendata.arcgis.com/datasets/contour-lines-1993) as an example.  Because it is defined after the LIDAR data, the LIDAR dataset is used if it covers the required area, falling back to this contour set for input files that are covered by it but not the LIDAR.
+The enclosed [datasources.json](datasources.json) sets up [Seattle's open 2ft contour dataset](https://data-seattlecitygis.opendata.arcgis.com/datasets/contour-lines-1993) as an example.  Because it is defined after the LIDAR data, the LIDAR dataset is used if it covers the required area, falling back to this contour set for input files that are covered by it but not the LIDAR.  In practice this means it will very rarely be used; consider it more a demo than a practical feature.  In our testing we've found that the LIDAR data gets us very similar results in a fraction of the processing time.
 
 **Important note**: a point's elevation is taken only from the nearest contour to it, with no attempt to interpolate.  This works well for 2ft contours in a hilly area, but may become a significant source of error for flatter regions or more widely spaced contours.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ It is also possible to configure locally preferred data sources.  See [below](#a
 
 Data files may be in any of the [vector formats supported by GDAL](https://gdal.org/drivers/vector/index.html), though note that for formats not marked as "Built-in by default" you may need to install additional prerequisites.  All common vector formats are supported by default.
 
-The enclosed [datasources.json](datasources.json) sets up [Seattle's open 2ft contour dataset](https://data-seattlecitygis.opendata.arcgis.com/datasets/contour-lines-1993) as an example.
+The enclosed [datasources.json](datasources.json) sets up [Seattle's open 2ft contour dataset](https://data-seattlecitygis.opendata.arcgis.com/datasets/contour-lines-1993) as an example.  Because it is defined after the LIDAR data, the LIDAR dataset is used if it covers the required area, falling back to this contour set for input files that are covered by it but not the LIDAR.
 
 **Important note**: a point's elevation is taken only from the nearest contour to it, with no attempt to interpolate.  This works well for 2ft contours in a hilly area, but may become a significant source of error for flatter regions or more widely spaced contours.
 
@@ -55,7 +55,7 @@ The enclosed [datasources.json](datasources.json) sets up [Seattle's open 2ft co
 
 Data files may be in any of the [raster formats supported by GDAL](https://gdal.org/drivers/raster/index.html), though note that for formats not marked as "Built-in by default" you may need to install additional prerequisites.  All common raster formats are supported by default.
 
-The enclosed [datasources.json](datasources.json) sets up "Delivery 1" from the Puget Sound LiDAR Consortium's [2016 King County data](http://pugetsoundlidar.ess.washington.edu/lidardata/restricted/projects/2016king_county.html) as an example.  It covers Seattle as well as some additional area S and E of Seattle.  Because it is defined after the Seattle 2ft contours, the contour dataset is used if it covers the required area, falling back to this LIDAR set for input files that are covered by it but not the contours.
+The enclosed [datasources.json](datasources.json) sets up "Delivery 1" from the Puget Sound LiDAR Consortium's [2016 King County data](http://pugetsoundlidar.ess.washington.edu/lidardata/restricted/projects/2016king_county.html) as an example.  It covers Seattle as well as some additional area S and E of Seattle.
 
 ## Input format
 

--- a/datasources.json
+++ b/datasources.json
@@ -1,18 +1,6 @@
 {
 	"sources": [
 		{
-			"name": "Seattle 2ft contours",
-			"url": "https://opendata.arcgis.com/datasets/1545ab0b0fcc492886be92be25a9faa5_0.geojson",
-			"filename": "seattle_contours.geojson",
-			"crs": "EPSG:4326",
-			"bbox": [-122.4359526776817120,47.4448428851168060, -122.2173553791662357,47.7779711955390596],
-			"download_method": "http",
-			"lookup_method": "contour_lines",
-			"lookup_field": "CL93_ELEV",
-			"units": "feet",
-			"recheck_interval_days": 30
-		},
-		{
 			"name": "King County 2016 LIDAR, block 1 (Seattle & Lake Washington)",
 			"url": "ftp://ftp.coast.noaa.gov/pub/DigitalCoast/raster2/elevation/WA_King_DEM_2016_8589/kingcounty_delivery1_be.tif",
 			"filename": "kc_2016_lidar.tif",
@@ -23,6 +11,18 @@
 			"lookup_field": 1,
 			"units": "feet",
 			"recheck_interval_days": 100
+		},
+		{
+			"name": "Seattle 2ft contours",
+			"url": "https://opendata.arcgis.com/datasets/1545ab0b0fcc492886be92be25a9faa5_0.geojson",
+			"filename": "seattle_contours.geojson",
+			"crs": "EPSG:4326",
+			"bbox": [-122.4359526776817120,47.4448428851168060, -122.2173553791662357,47.7779711955390596],
+			"download_method": "http",
+			"lookup_method": "contour_lines",
+			"lookup_field": "CL93_ELEV",
+			"units": "feet",
+			"recheck_interval_days": 30
 		}
 	]
 }


### PR DESCRIPTION
… LIDAR data to the 2ft contours.

These are two changes I always make locally to test your PRs, so I figured upstreaming them makes sense. The `apt-get update` is necessary to build Docker at all. I thought #11 would go through more easily, but I still need to spend some more time getting GDAL to build without clobbering the versions of other things.

At this point, I also think it's also clear that the LIDAR is preferable because of speed and quality being fine.