### PR TITLE
Docker file size fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@ ENV LANG C.UTF-8
 
 # Copy in the current project
 WORKDIR /elevation
-COPY . .
+COPY *.py .
+COPY *.json .
+COPY *.txt .
 
 # Build dependencies
 RUN apt-get update


### PR DESCRIPTION
The COPY command in the Dockerfile was copying the entire contents of my `data` subdirectory.  When I had a copy of the King County LIDAR saved there that was enough to break things.  This update just makes it a little more selective about what gets copied in.