### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ ENV LANG C.UTF-8
 
 # Copy in the current project
 WORKDIR /elevation
-COPY *.py .
-COPY *.json .
-COPY *.txt .
+COPY *.py ./
+COPY *.json ./
+COPY *.txt ./
 
 # Build dependencies
 RUN apt-get update


### PR DESCRIPTION
Without the trailing slash, I got a "When using COPY with more than one source file, the destination must be a directory..." error

Also, https://hub.docker.com/r/abstreet/elevation_lookups now exists!