### PR TITLE
Add a UK datasource

### DIFF
--- a/datasources.json
+++ b/datasources.json
@@ -23,6 +23,18 @@
 			"lookup_field": "CL93_ELEV",
 			"units": "feet",
 			"recheck_interval_days": 30
+		},
+		{
+			"name": "OS Terrain 50",
+			"url": "http://abstreet.s3-website.us-east-2.amazonaws.com/dev/data/input/shared/elevation/UK-dem-50m-4326.tif",
+			"filename": "UK-dem-50m-4326.tif",
+			"crs": "EPSG:4326",
+			"bbox": [-9.35049789,49.76665728, 2.7882733,60.9525423],
+			"download_method": "http",
+			"lookup_method": "raster",
+			"lookup_field": 1,
+			"units": "meters",
+			"recheck_interval_days": null
 		}
 	]
 }


### PR DESCRIPTION
@mem48 pointed me towards https://www.ordnancesurvey.co.uk/business-government/products/terrain-50, which he's processed using https://github.com/mem48/OTPR/blob/master/scripts/prep_DEM.R. I've done quick end-to-end tests in A/B Street and the results look reasonable! https://hub.docker.com/r/abstreet/elevation_lookups has been updated already too.

I'm hosting the file in my S3 bucket, but the instructions to reproduce are in the R script above.