### PR TITLE
Add Brest, FR 50cm contours

### DIFF
--- a/datasources.json
+++ b/datasources.json
@@ -35,6 +35,18 @@
 			"lookup_field": 1,
 			"units": "meters",
 			"recheck_interval_days": null
+		},
+		{
+			"name": "Brest 50cm contours",
+			"url": "https://play.abstreet.org/dev/data/input/shared/elevation/brest.geojson.gz",
+			"filename": "brest_contours.geojson",
+			"crs": "ESRI:102110",
+			"bbox": [-4.552179, 48.355777, -4.434689727004813, 48.44768660963146],
+			"download_method": "http",
+			"lookup_method": "contour_lines",
+			"lookup_field": "ELEVATION",
+			"units": "meters",
+			"recheck_interval_days": null
 		}
 	]
 }


### PR DESCRIPTION
Original data source: https://geo.brest-metropole.fr/portal/home/item.html?id=c0e498ab9b2547659b5a76509c99bc00

The bbox currently roughly matches https://github.com/a-b-street/abstreet/blob/main/importer/config/fr/brest/city.geojson
We can enlarge it later on once larger zones of the metro area make it to abstreet.

I'm not much familiar with how `elevation_lookups` and `abstreet` interact together so feel free to modify this commit or guide me on what needs to change.

Fixes #32